### PR TITLE
LSST DESC Note: Machine Learning Prediction of PhoSim CPU Time

### DIFF
--- a/doc/LSST_DESC_Notes/README.md
+++ b/doc/LSST_DESC_Notes/README.md
@@ -7,7 +7,7 @@ Each Twinkles Note is being developed in its own branch, from where it can be re
 * "The Twinkles 1 Supernova Population", Biswas et al in prep.
 * ["The Twinkles 1 Strong Lens Population,"](https://github.com/LSSTDESC/Twinkles/blob/issue/449/twinkles1-sl-pop-note/doc/LSST_DESC_Notes/desc-0000-twinkles-1-sl-pop/main.ipynb) Kalmbach et al in prep. [`issue/449/twinkles1-sl-pop-note`](https://github.com/LSSTDESC/Twinkles/blob/issue/449/twinkles1-sl-pop-note/doc/LSST_DESC_Notes), PR:[#450](https://github.com/LSSTDESC/Twinkles/pulls/450)
 * ["The Twinkles 1 PhoSim Pipeline and Results"](https://github.com/LSSTDESC/Twinkles/blob/twinkles1-phosim-pipeline-note/doc/LSST_DESC_Notes/desc-0000-twinkles-1-phosim-pipeline/main.rst) Glanzman et al in prep. [`twinkles1-phosim-pipeline-note`](https://github.com/LSSTDESC/Twinkles/blob/twinkles1-phosim-pipeline-note/doc/LSST_DESC_Notes), PR:[#451](https://github.com/LSSTDESC/Twinkles/pulls/451)
-* "Machine-learning Prediction of PhoSim CPU Time," Digel et al in prep.
+* "Machine-learning Prediction of PhoSim CPU Time," Digel et al in prep. `phosim-cpu-prediction-note`, PR:452
 * "Twinkles 1 Emulated DM Level 2 Pipeline and Results" Krughoff & Johnson in prep.
 * ["Pserv"](https://github.com/LSSTDESC/pserv/blob/issue/16/desc-note/doc/desc-0000-pserv-note/main.ipynb) Chiang, Kalmbach & Kelly in prep. [`pserv:issue/16/desc-note`](https://github.com/LSSTDESC/pserv/blob/issue/16/desc-note/doc), PR:[pserv#17](https://github.com/LSSTDESC/pserv/pulls/17)
 * "The Monitor," Kalmbach, Biswas & Marshall in prep.


### PR DESCRIPTION
@digel 

Hi Seth! Here's a branch and PR for your DESC Note on the PhoSim CPU Time prediction work. Looking at the code and the example hack day notebook you made with @humnaawan and @tmcclintock, I think this Note would work well as an IPython notebook, that explains the problem and your solution before demonstrating the prediction code (now checked in to the Twinkles repo as a python module) on the Run 3 OpSim data (which the notebook could download via `$ curl`). I think you have done a lot of this analysis already, and the example notebook contains useful plotting code. What do you think? 

I guess Humna and Tom may have some spare cycles to help out with such a notebook. (Just remember to only check in after you have cleared the nb outputs, to make it easy for git to merge contributions from multiple authors). Alternatively I'm sure they'd be happy to help with text editing etc!

I was going to run `start_paper` to make a Note folder, but then realized that as PubMgr you might like to do this yourself so that you can see how it works (and what is missing from the docs etc :-) A good short title to use could be "phosim-cpu-prediction" so that the folder comes out as `desc-0000-twinkles-phosim-cpu-prediction`.