### PR TITLE
U/danielsf/truth/catalogs

### DIFF
--- a/data/dc2_defs.csv
+++ b/data/dc2_defs.csv
@@ -1,3 +1,4 @@
+galaxyAgn_sn_t0,agn_descqa_sn_t0
 galaxyAgn_sn_truth_params,agn_descqa_sn_truth_params
 galaxyAgn_is_sprinkled,agn_descqa_is_sprinkled
 galaxyDisk_is_sprinkled,disk_descqa_is_sprinkled

--- a/data/dc2_defs.csv
+++ b/data/dc2_defs.csv
@@ -1,3 +1,4 @@
+galaxyAgn_sn_truth_params,agn_descqa_sn_truth_params
 galaxyAgn_is_sprinkled,agn_descqa_is_sprinkled
 galaxyDisk_is_sprinkled,disk_descqa_is_sprinkled
 galaxyBulge_is_sprinkled,bulge_descqa_is_sprinkled

--- a/data/dc2_defs.csv
+++ b/data/dc2_defs.csv
@@ -8,7 +8,7 @@ galaxyAgn_redshift,agn_descqa_redshift
 galaxyAgn_varParamStr,agn_descqa_varParamStr
 pars,p
 varMethodName,m
-galtileid,agn_descqa_galaxy_id
+galtileid,agn_descqa_galaxy_id,bulge_descqa_galaxy_id,disk_descqa_galaxy_id
 galaxyBulge_raJ2000,bulge_descqa_raJ2000
 galaxyDisk_raJ2000,disk_descqa_raJ2000
 galaxyAgn_raJ2000,agn_descqa_raJ2000

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -73,7 +73,7 @@ class sprinkler():
             The results array from an instance catalog.
         visit_mjd: float
             The mjd of the visit
-        specFileMap: 
+        specFileMap:
             This will tell the instance catalog where to write the files
         om10_cat: optional, defaults to 'twinkles_lenses_v2.fits
             fits file with OM10 catalog
@@ -137,7 +137,7 @@ class sprinkler():
             if re.match(key, specFileStart):
                 galSpecDir = str(val)
         self.galDir = str(getPackageDir('sims_sed_library') + '/' + galSpecDir + '/')
-        
+
         self.imSimBand = Bandpass()
         self.imSimBand.imsimBandpass()
         #self.LRG_name = 'Burst.25E09.1Z.spec'
@@ -160,7 +160,7 @@ class sprinkler():
                                                              self.bandpassDict))
         #self.src_mag_norm = matchBase().calcMagNorm(src_iband,
         #                                            [agn_sed]*len(src_iband),
-        #             
+        #
         #                                            self.bandpassDict)
 
         has_sn_truth_params = False
@@ -209,7 +209,7 @@ class sprinkler():
                 np.random.seed(galtileid % (2^32 -1))
                 pick_value = np.random.uniform()
             # If there aren't any lensed sources at this redshift from OM10 move on the next object
-                if (((len(candidates) > 0) and (pick_value <= self.density_param) and (self.cached_sprinkling is False)) | 
+                if (((len(candidates) > 0) and (pick_value <= self.density_param) and (self.cached_sprinkling is False)) |
                     ((self.cached_sprinkling is True) and (galtileid in self.agn_cache['galtileid'].values))):
                     # Randomly choose one the lens systems
                     # (can decide with or without replacement)
@@ -273,7 +273,7 @@ class sprinkler():
 
                                 lensrow[col_name] = ((lensrow[col_name]+30000000)*10000 +
                                                         newlens['twinklesId']*4 + i)
- 
+
 
                         updated_catalog = np.append(updated_catalog, lensrow)
 
@@ -297,7 +297,7 @@ class sprinkler():
                     row_lens_sed = Sed()
                     row_lens_sed.readSED_flambda(str(self.galDir + newlens['lens_sed']))
                     row_lens_sed.redshiftSED(newlens['ZLENS'], dimming=True)
-                    row[self.defs_dict['galaxyBulge_magNorm']] = matchBase().calcMagNorm([newlens['APMAG_I']], row_lens_sed, 
+                    row[self.defs_dict['galaxyBulge_magNorm']] = matchBase().calcMagNorm([newlens['APMAG_I']], row_lens_sed,
                                                                          self.bandpassDict) #Changed from i band to imsimband
                     row[self.defs_dict['galaxyBulge_majorAxis']] = radiansFromArcsec(newlens['REFF'] / np.sqrt(1 - newlens['ELLIP']))
                     row[self.defs_dict['galaxyBulge_minorAxis']] = radiansFromArcsec(newlens['REFF'] * np.sqrt(1 - newlens['ELLIP']))
@@ -332,7 +332,7 @@ class sprinkler():
                     np.random.seed(galtileid % (2^32 -1))
                     use_system = np.random.choice(unused_sysno)
                     use_df = self.sne_catalog.query('twinkles_sysno == %i' % use_system)
-                
+
                 for i in range(len(use_df)):
                     lensrow = row.copy()
                     for lensPart in ['galaxyBulge', 'galaxyDisk', 'galaxyAgn']:
@@ -372,7 +372,7 @@ class sprinkler():
                         for col_name in self.defs_dict['galtileid']:
                             lensrow[col_name] = ((lensrow[col_name]+30000000)*10000 +
                                                     use_system*4 + i)
- 
+
 
                     (add_to_cat, sn_magnorm,
                      sn_fname, sn_param_dict) = self.create_sn_sed(use_df.iloc[i],
@@ -395,7 +395,7 @@ class sprinkler():
                         lensrow[self.defs_dict['galaxyAgn_is_sprinkled']] = 1
                         lensrow[self.defs_dict['galaxyBulge_is_sprinkled']] = 1
                         lensrow[self.defs_dict['galaxyDisk_is_sprinkled']] = 1
-                    
+
                     if add_to_cat is True:
                         updated_catalog = np.append(updated_catalog, lensrow)
                     else:
@@ -432,7 +432,7 @@ class sprinkler():
                 #Replace original entry with new entry
                 updated_catalog[rowNum] = row
 
-                    
+
         return updated_catalog
 
     def find_lens_candidates(self, galz, gal_mag):
@@ -445,7 +445,7 @@ class sprinkler():
         return lens_candidates
 
     def find_sne_lens_candidates(self, galz):
-        
+
         w = np.where((np.abs(np.log10(self.sne_catalog['zs']) - np.log10(galz)) <= 0.1))
         lens_candidates = self.sne_catalog.iloc[w]
 
@@ -460,15 +460,15 @@ class sprinkler():
         sn_param_dict['c'] = system_df['c']
         sn_param_dict['x0'] = system_df['x0']
         sn_param_dict['x1'] = system_df['x1']
-        sn_param_dict['t0'] = system_df['t_start'] 
+        sn_param_dict['t0'] = system_df['t_start']
         #sn_param_dict['t0'] = 62746.27  #+1500. ### For testing only
-        
+
         current_sn_obj = self.sn_obj.fromSNState(sn_param_dict)
         current_sn_obj.mwEBVfromMaps()
         wavelen_max = 1800.
         wavelen_min = 30.
         wavelen_step = 0.1
-        sn_sed_obj = current_sn_obj.SNObjectSED(time=sed_mjd, 
+        sn_sed_obj = current_sn_obj.SNObjectSED(time=sed_mjd,
                                                 wavelen=np.arange(wavelen_min, wavelen_max,
                                                                   wavelen_step))
         flux_500 = sn_sed_obj.flambda[np.where(sn_sed_obj.wavelen >= 499.99)][0]

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -256,7 +256,7 @@ class sprinkler():
                         #just use np.right_shift(phosimID-28, 10). Take the floor of the last
                         #3 numbers to get twinklesID in the twinkles lens catalog and the remainder is
                         #the image number minus 1.
-                        lensrow[self.defs_dict['galtileid']] = (lensrow[self.defs_dict['galtileid']]*10000 +
+                        lensrow[self.defs_dict['galtileid']] = ((lensrow[self.defs_dict['galtileid']]+30000000)*10000 +
                                                 newlens['twinklesId']*4 + i)
 
                         updated_catalog = np.append(updated_catalog, lensrow)
@@ -349,7 +349,7 @@ class sprinkler():
                     #just use np.right_shift(phosimID-28, 10). Take the floor of the last
                     #3 numbers to get twinklesID in the twinkles lens catalog and the remainder is
                     #the image number minus 1.
-                    lensrow[self.defs_dict['galtileid']] = (lensrow[self.defs_dict['galtileid']]*10000 +
+                    lensrow[self.defs_dict['galtileid']] = ((lensrow[self.defs_dict['galtileid']]+30000000)*10000 +
                                             use_system*4 + i)
 
                     (add_to_cat, sn_magnorm,

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -415,7 +415,7 @@ class sprinkler():
         sn_param_dict['x0'] = system_df['x0']
         sn_param_dict['x1'] = system_df['x1']
         sn_param_dict['t0'] = system_df['t_start'] 
-        # sn_param_dict['t0'] = 61681.083859  #+1500. ### For testing only
+        sn_param_dict['t0'] = 62746.27  #+1500. ### For testing only
         
         current_sn_obj = self.sn_obj.fromSNState(sn_param_dict)
         current_sn_obj.mwEBVfromMaps()

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -17,7 +17,7 @@ import shutil
 from lsst.utils import getPackageDir
 from lsst.sims.utils import SpecMap
 from lsst.sims.catUtils.baseCatalogModels import GalaxyTileCompoundObj
-from lsst.sims.photUtils.matchUtils import matchBase
+from lsst.sims.catUtils.matchSED import matchBase
 from lsst.sims.photUtils import Bandpass, BandpassDict, Sed
 from lsst.sims.utils import radiansFromArcsec
 from lsst.sims.catUtils.supernovae import SNObject

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -439,7 +439,7 @@ class sprinkler():
         sn_param_dict['x0'] = system_df['x0']
         sn_param_dict['x1'] = system_df['x1']
         sn_param_dict['t0'] = system_df['t_start'] 
-        sn_param_dict['t0'] = 62746.27  #+1500. ### For testing only
+        #sn_param_dict['t0'] = 62746.27  #+1500. ### For testing only
         
         current_sn_obj = self.sn_obj.fromSNState(sn_param_dict)
         current_sn_obj.mwEBVfromMaps()

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -338,8 +338,12 @@ class sprinkler():
                     lensrow[self.defs_dict['galtileid']] = (lensrow[self.defs_dict['galtileid']]*10000 +
                                             use_system*4 + i)
 
-                    add_to_cat, sn_magnorm, sn_fname = self.create_sn_sed(use_df.iloc[i], lensrow[self.defs_dict['galaxyAgn_raJ2000']],
-                                                                lensrow[self.defs_dict['galaxyAgn_decJ2000']], self.visit_mjd)
+                    (add_to_cat, sn_magnorm,
+                     sn_fname, sn_param_dict) = self.create_sn_sed(use_df.iloc[i],
+                                                                   lensrow[self.defs_dict['galaxyAgn_raJ2000']],
+                                                                   lensrow[self.defs_dict['galaxyAgn_decJ2000']],
+                                                                   self.visit_mjd)
+
                     lensrow[self.defs_dict['galaxyAgn_sedFilename']] = sn_fname
                     lensrow[self.defs_dict['galaxyAgn_magNorm']] = sn_magnorm #This will need to be adjusted to proper band
                     mag_adjust = 2.5*np.log10(np.abs(use_df['mu'].iloc[i]))
@@ -443,7 +447,7 @@ class sprinkler():
             sn_name = None
 
 
-        return add_to_cat, sn_magnorm, sn_name
+        return add_to_cat, sn_magnorm, sn_name, current_sn_obj.SNstate
 
     def update_catsim(self):
         # Remove the catsim object

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -158,14 +158,23 @@ class sprinkler():
         #             
         #                                            self.bandpassDict)
 
+        has_sn_truth_params = False
+        for name in self.catalog_column_names:
+            if 'sn_truth_params' in name:
+                has_sn_truth_params = True
+                break
+
         self.defs_dict = {}
         self.logging_is_sprinkled = False
+        self.store_sn_truth_params = False
         with open(self.defs_file, 'r') as f:
             for line in f:
                 line_defs = line.split(',')
                 if len(line_defs) > 1:
                     if 'is_sprinkled' in line_defs[1]:
                         self.logging_is_sprinkled = True
+                    if 'sn_truth_params' in line_defs[1] and has_sn_truth_params:
+                        self.store_sn_truth_params = True
                     self.defs_dict[line_defs[0]] = line_defs[1].split('\n')[0]
 
     def sprinkle(self):
@@ -348,6 +357,9 @@ class sprinkler():
                     lensrow[self.defs_dict['galaxyAgn_magNorm']] = sn_magnorm #This will need to be adjusted to proper band
                     mag_adjust = 2.5*np.log10(np.abs(use_df['mu'].iloc[i]))
                     lensrow[self.defs_dict['galaxyAgn_magNorm']] -= mag_adjust
+
+                    if self.store_sn_truth_params:
+                        lensrow[self.defs_dict['galaxyAgn_sn_truth_params']] = json.dumps(sn_param_dict)
 
                     if self.logging_is_sprinkled:
                         lensrow[self.defs_dict['galaxyAgn_is_sprinkled']] = 1

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -365,6 +365,7 @@ class sprinkler():
                     lensrow[self.defs_dict['galaxyAgn_magNorm']] -= mag_adjust
 
                     if self.store_sn_truth_params:
+                        add_to_cat = True
                         lensrow[self.defs_dict['galaxyAgn_sn_truth_params']] = json.dumps(sn_param_dict)
 
                     if self.logging_is_sprinkled:

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -453,6 +453,7 @@ class sprinkler():
         if flux_500 > 0.:
             add_to_cat = True
             sn_magnorm = current_sn_obj.catsimBandMag(self.imSimBand, sed_mjd)
+            sn_name = None
             if write_sn_sed:
                 sn_name = 'specFileGLSN_%i_%i_%.4f.txt' % (system_df['twinkles_sysno'],
                                                            system_df['imno'], sed_mjd)

--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -367,6 +367,7 @@ class sprinkler():
                     if self.store_sn_truth_params:
                         add_to_cat = True
                         lensrow[self.defs_dict['galaxyAgn_sn_truth_params']] = json.dumps(sn_param_dict)
+                        lensrow[self.defs_dict['galaxyAgn_sn_t0']] = sn_param_dict['t0']
 
                     if self.logging_is_sprinkled:
                         lensrow[self.defs_dict['galaxyAgn_is_sprinkled']] = 1


### PR DESCRIPTION
This PR adds functionality I needed to generate the DC2 truth catalogs.  Mainly, that means adding code to allow access to SNe parameters, even when the SNe is not currently going off.

I also did a little bit of munging on the `galaxy_id` question to get it to work for protoDC2.  We will need a more permanent fix for CosmoDC2, as Bryce and I discussed a few days ago.