### PR TITLE
Adjust for CosmoDC2_v1.0 galaxies.

### DIFF
--- a/python/desc/twinkles/sprinkler.py
+++ b/python/desc/twinkles/sprinkler.py
@@ -266,12 +266,12 @@ class sprinkler():
                         #3 numbers to get twinklesID in the twinkles lens catalog and the remainder is
                         #the image number minus 1.
                         if not isinstance(self.defs_dict['galtileid'], tuple):
-                            lensrow[self.defs_dict['galtileid']] = ((lensrow[self.defs_dict['galtileid']]+30000000)*10000 +
+                            lensrow[self.defs_dict['galtileid']] = ((lensrow[self.defs_dict['galtileid']]+int(1.5e10))*10000 +
                                                     newlens['twinklesId']*4 + i)
                         else:
                             for col_name in self.defs_dict['galtileid']:
 
-                                lensrow[col_name] = ((lensrow[col_name]+30000000)*10000 +
+                                lensrow[col_name] = ((lensrow[col_name]+int(1.5e10))*10000 +
                                                         newlens['twinklesId']*4 + i)
 
 
@@ -366,11 +366,11 @@ class sprinkler():
                     #3 numbers to get twinklesID in the twinkles lens catalog and the remainder is
                     #the image number minus 1.
                     if not isinstance(self.defs_dict['galtileid'], tuple):
-                        lensrow[self.defs_dict['galtileid']] = ((lensrow[self.defs_dict['galtileid']]+30000000)*10000 +
+                        lensrow[self.defs_dict['galtileid']] = ((lensrow[self.defs_dict['galtileid']]+int(1.5e10))*10000 +
                                                 use_system*4 + i)
                     else:
                         for col_name in self.defs_dict['galtileid']:
-                            lensrow[col_name] = ((lensrow[col_name]+30000000)*10000 +
+                            lensrow[col_name] = ((lensrow[col_name]+int(1.5e10))*10000 +
                                                     use_system*4 + i)
 
 


### PR DESCRIPTION
The biggest `galaxy_id` in `cosmoDC2_v1.0_image` is ~ 1.44e10. Here I change the id scheme in the sprinkler to (`galaxy_id` + 1.5e10) * 10000 + `twinkles_system`*4 + `image_number` — where `twinkles_system`*4 + `image_number` is less than 10000 —  and when we left_shift we remain under the 2**63 limit still.